### PR TITLE
Replace format icons with text (for now)

### DIFF
--- a/app/views/admin/root/_publication.html.erb
+++ b/app/views/admin/root/_publication.html.erb
@@ -4,7 +4,7 @@
 <tr>
 <% end %>
   <td class="icon">
-    <%= image_tag "icon-#{publication.format.downcase}.png", :title => publication.format.humanize %>
+    <%= publication.format.humanize %>
   </td>
   <td class="business">
     <%= publication.business_proposition ? 'Y' : 'N' %>

--- a/app/views/admin/root/_published_edition.html.erb
+++ b/app/views/admin/root/_published_edition.html.erb
@@ -4,7 +4,7 @@
 <tr>
 <% end %>
   <td class="icon">
-    <%= image_tag "icon-#{publication.format.downcase}.png", :title => publication.format.humanize %>
+    <%= publication.format.humanize %>
   </td>
   <td>
     <%= publication.business_proposition ? 'Y' : 'N' %>

--- a/app/views/admin/user_search/index.html.erb
+++ b/app/views/admin/user_search/index.html.erb
@@ -42,7 +42,7 @@
             <% @editions.each do |publication| %>
             <tr>
               <td class="icon">
-                <%= image_tag "icon-#{publication.format.downcase}.png", :title => publication.format.humanize %>
+                <%= publication.format.humanize %>
               </td>
               <td class="title">
                 <%= publication.admin_list_title %>


### PR DESCRIPTION
We don't have icons for all the formats, and the broken images caused issues in production (becasue asset pipeline), so I've repla
ced them with text for now. Would be nicer to have icons in future though - maybe using font awesome.
