### PR TITLE
Add asset importer Rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ gem 'foreman'
 gem 'bootstrap-datepicker-rails'
 gem 'country-select', :github => 'ninkibah/country-select'
 gem 'epic-editor-rails', :github => 'zethussuen/epic-editor-rails'
+gem 'fog'
 
 group :assets do
   gem "therubyracer", "~> 0.9.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,7 @@ GEM
     eventmachine (1.0.3)
     exception_notification (2.6.1)
       actionmailer (>= 3.0.4)
+    excon (0.25.3)
     execjs (1.4.0)
       multi_json (~> 1.0)
     factory_girl (3.6.1)
@@ -167,9 +168,20 @@ GEM
     faraday (0.8.6)
       multipart-post (~> 1.1)
     ffi (1.8.1)
+    fog (1.15.0)
+      builder
+      excon (~> 0.25.0)
+      formatador (~> 0.2.0)
+      mime-types
+      multi_json (~> 1.0)
+      net-scp (~> 1.1)
+      net-ssh (>= 2.1.3)
+      nokogiri (~> 1.5)
+      ruby-hmac
     foreman (0.63.0)
       dotenv (>= 0.7)
       thor (>= 0.13.6)
+    formatador (0.2.4)
     gds-sso (3.0.5)
       omniauth-gds (~> 0.0.3)
       rack-accept (~> 0.4.4)
@@ -244,6 +256,9 @@ GEM
     multi_json (1.7.4)
     multi_xml (0.5.5)
     multipart-post (1.2.0)
+    net-scp (1.1.2)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.7.0)
     nokogiri (1.5.10)
     null_logger (0.0.1)
     oauth2 (0.8.1)
@@ -297,6 +312,7 @@ GEM
     retriable (1.3.2)
     reverse_markdown (0.3.0)
       nokogiri
+    ruby-hmac (0.4.0)
     rubyzip (0.9.9)
     sanitize (2.0.3)
       nokogiri (>= 1.4.4, < 1.6)
@@ -372,6 +388,7 @@ DEPENDENCIES
   exception_notification (= 2.6.1)
   factory_girl_rails
   faker (= 1.1.2)
+  fog
   foreman
   formtastic!
   formtastic-bootstrap!

--- a/lib/import_assets.rb
+++ b/lib/import_assets.rb
@@ -1,0 +1,62 @@
+require 'uri' 
+require 'fog'
+
+class AssetImporter
+  
+  def self.perform
+    ArticleEdition.all.each do |edition|
+      if edition.content     
+        matches = edition.content.scan /!\[.*?\]\((.*?)\)/
+        unless matches.nil?
+          matches.each do |match|
+            origin = match[0]
+            if origin.start_with?("/")
+              url = 'http://www.theodi.org' + origin
+            elsif origin.start_with?("theodi")
+              url = 'http://' + origin
+            else
+              url = origin
+            end
+            
+            puts edition.slug
+            puts url
+            
+            new_url = upload(url)
+            
+            unless new_url.nil?
+              edition.content = edition.content.gsub(origin, new_url)
+              edition.save(validate: false) 
+            end
+            
+          end
+        end
+      end
+    end
+  end
+  
+  def self.service
+    Fog::Storage.new({
+                  :provider            => 'Rackspace',
+                  :rackspace_username  => ENV['RACKSPACE_USERNAME'],
+                  :rackspace_api_key   => ENV['RACKSPACE_API_KEY'],
+                  :rackspace_auth_url  => Fog::Rackspace::UK_AUTH_ENDPOINT,
+                  :rackspace_region    => :lon
+    })
+  end
+  
+  def self.upload(url)
+    dir = service.directories.get ENV['QUIRKAFLEEG_ASSET_MANAGER_RACKSPACE_CONTAINER']
+    
+    body = open(url) rescue nil
+    
+    unless body.nil?    
+      uri = URI.parse(url)
+      filename = File.basename(uri.path)
+      destination = URI.unescape(filename).gsub(" ", "-")
+    
+      file = dir.files.create :key => "uploads/assets/legacy/" + destination, :body => body
+      file.public_url
+    end
+  end
+  
+end

--- a/lib/tasks/asset_importer.rake
+++ b/lib/tasks/asset_importer.rake
@@ -1,0 +1,7 @@
+namespace :assets do
+  desc "Import assets"
+  task :import => :environment do
+    require 'import_assets'
+    AssetImporter.perform
+  end
+end


### PR DESCRIPTION
This adds a rake task to pull all the inline images out of Article content and upload them to Rackspace. It doesn't (yet) create asset objects, but at least ensures that they're in the right place.
