### PR TITLE
Precompile Epic Editor Base CSS

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,7 +57,7 @@ Publisher::Application.configure do
   # Generate digests for assets URLs.
   config.assets.digest = true
   
-  config.assets.precompile += %w( preview/bartik.css preview/github.css preview/preview-dark.css editor/epic-dark.css editor/epic-light.css )
+  config.assets.precompile += %w( preview/bartik.css preview/github.css preview/preview-dark.css editor/epic-dark.css editor/epic-light.css base/epiceditor.css )
 
   config.action_mailer.default_url_options = { :host => "www.#{ENV['GOVUK_APP_DOMAIN']}" }
   config.action_mailer.delivery_method = :smtp


### PR DESCRIPTION
This should fix the issue with the Epic Editor preview links not showing up
