### PR TITLE
Return to alphagov govuk_content_models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,8 @@ else
   gem 'gds-sso', '~> 3.0.5'
 end
 
-gem "govuk_content_models", github: 'theodi/govuk_content_models', branch: 'feature-lambda-format-validator'
+gem "govuk_content_models", '6.0.6'
+
 if ENV['CONTENT_MODELS_DEV']
   gem "odi_content_models", path: '../odi_content_models'
 else
@@ -42,7 +43,7 @@ gem 'has_scope'
 gem 'inherited_resources'
 gem 'kaminari', '0.13.0'
 gem 'lograge', '0.2.0'
-gem 'mongo', '1.6.2'  # Locking this down to avoid a replica set bug
+gem 'mongo', '1.7.1'
 gem "mongoid_rails_migrations", "1.0.0"
 gem 'null_logger'
 gem 'plek', '1.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,21 +16,6 @@ GIT
       rest-client (~> 1.6.3)
 
 GIT
-  remote: git://github.com/theodi/govuk_content_models.git
-  revision: 77bbd75991f54dc304c0bd289c271785fc586fd9
-  branch: feature-lambda-format-validator
-  specs:
-    govuk_content_models (5.10.0)
-      bson_ext
-      differ
-      gds-api-adapters
-      gds-sso (>= 3.0.0, < 4.0.0)
-      govspeak (>= 1.0.1, < 2.0.0)
-      mongoid (~> 2.4.10)
-      plek
-      state_machine
-
-GIT
   remote: git://github.com/theodi/odi_content_models.git
   revision: 67550837282f8915384b0b74ff0d8b722271a0bf
   specs:
@@ -124,9 +109,9 @@ GEM
       xml-simple
     bootstrap-datepicker-rails (1.1.1.7)
       railties (>= 3.0)
-    bson (1.6.4)
-    bson_ext (1.6.4)
-      bson (~> 1.6.4)
+    bson (1.7.1)
+    bson_ext (1.7.1)
+      bson (~> 1.7.1)
     builder (3.0.4)
     capybara (1.1.4)
       mime-types (>= 1.16)
@@ -191,6 +176,15 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
+    govuk_content_models (6.0.6)
+      bson_ext
+      differ
+      gds-api-adapters
+      gds-sso (>= 3.0.0, < 4.0.0)
+      govspeak (>= 1.0.1, < 2.0.0)
+      mongoid (~> 2.5)
+      plek
+      state_machine
     has_scope (0.5.1)
     hashie (2.0.5)
     hike (1.2.2)
@@ -242,11 +236,11 @@ GEM
       redis
     mocha (0.13.3)
       metaclass (~> 0.0.1)
-    mongo (1.6.2)
-      bson (~> 1.6.2)
-    mongoid (2.4.12)
+    mongo (1.7.1)
+      bson (~> 1.7.1)
+    mongoid (2.6.0)
       activemodel (~> 3.1)
-      mongo (<= 1.6.2)
+      mongo (~> 1.7)
       tzinfo (~> 0.3.22)
     mongoid_rails_migrations (1.0.0)
       activesupport (>= 3.2.0)
@@ -396,7 +390,7 @@ DEPENDENCIES
   formtastic-bootstrap!
   gds-api-adapters!
   gds-sso (~> 3.0.5)
-  govuk_content_models!
+  govuk_content_models (= 6.0.6)
   has_scope
   inherited_resources
   jquery-rails
@@ -407,7 +401,7 @@ DEPENDENCIES
   minitest (= 3.3.0)
   mlanett-redis-lock (= 0.2.2)
   mocha (= 0.13.3)
-  mongo (= 1.6.2)
+  mongo (= 1.7.1)
   mongoid_rails_migrations (= 1.0.0)
   nested_form!
   null_logger


### PR DESCRIPTION
First part of upgrade all the things, let's get back to using the main alphagov content_models.

This PR gets us to govuk_content_models 6.0.6. I had to upgrade some mongo things as well so I would advise we merge this in the morning @pikesley so we can reboot anything that needs it.
