### PR TITLE
In Progress: Add Keyword Management To Publisher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'formtastic-bootstrap', git: 'https://github.com/cgunther/formtastic-bootstr
 gem 'gds-api-adapters', :github => 'theodi/gds-api-adapters'
 
 gem "nested_form", git: 'https://github.com/alphagov/nested_form.git', branch: 'add-wrapper-class'
+gem 'tagmanager-rails'
 
 if ENV['ODIDOWN_DEV']
   gem 'odidown', path: '../odidown'
@@ -58,7 +59,7 @@ gem 'reverse_markdown', '~> 0.3.0', require: false # Only used in some importers
 gem 'statsd-ruby', '1.0.0', require: false
 gem 'whenever', require: false
 
-gem 'jquery-rails'
+gem 'jquery-rails', '2.0.2'
 gem 'less-rails-bootstrap', '~> 2.0.0'
 gem 'thin'
 gem 'foreman', '< 0.65.0'
@@ -72,6 +73,10 @@ gem 'mongoid-tree'
 group :assets do
   gem "therubyracer", "~> 0.12.0"
   gem 'uglifier'
+end
+
+group :development do
+  gem 'quiet_assets'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,9 +277,9 @@ GEM
       responders (~> 0.9)
     ipaddress (0.8.0)
     journey (1.0.4)
-    jquery-rails (3.1.2)
-      railties (>= 3.0, < 5.0)
-      thor (>= 0.14, < 2.0)
+    jquery-rails (2.0.2)
+      railties (>= 3.2.0, < 5.0)
+      thor (~> 0.14)
     json (1.8.2)
     jwt (1.3.0)
     kaminari (0.13.0)
@@ -364,6 +364,8 @@ GEM
       http_parser.rb (~> 0.5.3)
       multi_json (~> 1.0)
     polyglot (0.3.5)
+    quiet_assets (1.1.0)
+      railties (>= 3.1, < 5.0)
     rack (1.4.5)
     rack-accept (0.4.5)
       rack (>= 0.4)
@@ -429,6 +431,8 @@ GEM
       tilt (~> 1.1, != 1.3.0)
     state_machine (1.2.0)
     statsd-ruby (1.0.0)
+    tagmanager-rails (3.0.1.0)
+      railties (>= 3.0, < 5.0)
     therubyracer (0.12.1)
       libv8 (~> 3.16.14.0)
       ref
@@ -486,7 +490,7 @@ DEPENDENCIES
   govuk_content_models (= 6.1.0)
   has_scope (= 0.5.1)
   inherited_resources (= 1.4)
-  jquery-rails
+  jquery-rails (= 2.0.2)
   kaminari (= 0.13.0)
   launchy
   less-rails-bootstrap (~> 2.0.0)
@@ -504,6 +508,7 @@ DEPENDENCIES
   odlifier!
   plek (= 1.4.0)
   poltergeist
+  quiet_assets
   rails (~> 3.2.16)
   redis (= 3.0.3)
   rest-client
@@ -513,6 +518,7 @@ DEPENDENCIES
   simplecov (~> 0.6.4)
   simplecov-rcov (~> 0.2.3)
   statsd-ruby (= 1.0.0)
+  tagmanager-rails
   therubyracer (~> 0.12.0)
   thin
   timecop

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,7 +6,8 @@
 //= require_directory .
 //= require jquery_nested_form
 //= require bootstrap-datepicker
-//= require epiceditor 
+//= require epiceditor
+//= require tagmanager
 
 // System wide behaviours
 $(function () {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -3,7 +3,8 @@
  * and any sub-directories. You're free to add application-wide styles to this file and they'll appear at
  * the top of the compiled file, but it's generally better to create a new file per style scope.
  *= require bootstrap-datepicker
- *= require base/epiceditor  
+ *= require base/epiceditor
  *= require dropzone
+ *= require tagmanager
  *= require_tree .
 */

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -15,6 +15,7 @@ class Admin::EditionsController < Admin::BaseController
     if @resource.is_a?(Parted)
       @ordered_parts = @resource.parts.in_order
     end
+    get_keywords
     render
   end
 
@@ -58,6 +59,9 @@ class Admin::EditionsController < Admin::BaseController
 
     update! do |success, failure|
       success.html {
+        # Set the keywords in panopticon
+        set_keywords
+
         # Automatically start work if we haven't already
         if resource.can_start_work?
           command = EditionProgressor.new(resource, current_user, statsd)
@@ -132,5 +136,30 @@ class Admin::EditionsController < Admin::BaseController
 
     def description(r)
       r.format.underscore.humanize
+    end
+
+  private
+    def get_keywords
+      if @resource.artefact
+        @keywords = @resource.artefact.keywords.map { |k| k.title }.join(", ")
+      end
+      @available_keywords = Tag.where(tag_type: "keyword").map { |k| k.title }
+    end
+
+    def set_keywords
+      new_keywords = create_keywords(params) if params[:edition][:keywords]
+
+      @resource.artefact.update_attributes!(keywords: new_keywords)
+      @resource.artefact.save
+    end
+
+    def create_keywords(params)
+      params[:edition][:keywords] = params[:edition][:keywords].split(',')
+      params[:edition][:keywords].each do |k|
+        Tag.find_or_create_by(tag_id: k.parameterize,
+                              title: k,
+                              tag_type: "keyword")
+      end
+      params[:edition][:keywords].map! { |k| k.parameterize }
     end
 end

--- a/app/views/admin/shared/_article.html.erb
+++ b/app/views/admin/shared/_article.html.erb
@@ -1,11 +1,11 @@
 <fieldset class='form-horizontal'>
-  
+
   <%= render partial: 'admin/shared/markdown_field', locals: { type: :content, form: f }%>
 
   <%= f.input :url,
               :as => :url,
               :input_html => { :class => 'span7' , :disabled => @resource.published?, } %>
- 
+
   <div class="control-group">
     <label class="control-label">Attachments</label>
     <div class="controls">
@@ -18,7 +18,7 @@
 
 <fieldset class='form-horizontal'>
   <legend>Media Enquiries</legend>
-  
+
   <%= f.input :media_enquiries_name,
               :label => "Name",
               :input_html => { :class => 'span7' , :disabled => @resource.published? } %>

--- a/app/views/admin/shared/_title_etc.html.erb
+++ b/app/views/admin/shared/_title_etc.html.erb
@@ -22,4 +22,14 @@
         :hint => 'Some search engines will display this if they can&rsquo;t find what they need in the main text',
         :input_html => { :class => "span7", :rows => 3, :disabled => @resource.published? } %>
 
+    <%= f.label "keywords", class: 'control-label section-label' %>
+
+    <div class='controls' id='keyword-controls'>
+      <%= text_field_tag :keywords, "", {
+        :class => "keyword-tags",
+        :disabled => !current_user.permissions.include?("keywords"),
+        :autocomplete => "off"
+        } %>
+    </div>
+
 </fieldset>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -84,5 +84,36 @@
     });
   </script>
 
+  <%# Adding this here because it's needed in all sub pages, and I'm not sure how those are organized. There might be a way to take this tagsManager script and put it in a less "global" place. %>
+  <script type="text/javascript">
+
+    $(".keyword-tags").tagsManager({
+      prefilled: '<%= @keywords %>',
+      hiddenTagListName: 'edition[keywords]'
+    });
+
+    $(".keyword-tags").typeahead({
+      hint: true,
+      highlight: true,
+      limit: 15,
+      source: [<%= @available_keywords.map{|x| "\"#{x}\""}.join(',').html_safe rescue nil %>],
+      updater: function(selection){
+        $("#keywords").val(selection);
+        addTag();
+      }
+    });
+
+    $("#edit_artefact").submit(function() {
+      addTag();
+    })
+
+    function addTag() {
+      console.log('add tag');
+      $("#keywords").trigger({ type : 'keypress', which : 44 })
+    }
+
+  </script>
+
+
 </body>
 </html>


### PR DESCRIPTION
Based off of keyword management in Panopticon, this adds keyword management to the publisher edition screen, if the user has keyword adding permissions.

To do:
* [ ] pass tests locally (though I don't know if they're failing because of these additions or they're just failing. Travis will tell.
* [ ] add tests for this feature.