### PR TITLE
Adding extra levels to Node form in publisher

### DIFF
--- a/app/views/admin/shared/_node.html.erb
+++ b/app/views/admin/shared/_node.html.erb
@@ -2,7 +2,14 @@
 
   <%= f.input :level,
               :as => :select,
-              :collection => ["country","city","comms"],
+              :collection => [
+                ["Country", "country"],
+                ["City", "city"],
+                ["Comms", "comms"],
+                ["Learning", "learning"],
+                ["Network", "network"],
+                ["Network & Learning", "network_learning"]
+              ],
               :include_blank => 'Please select',
               :input_html => { :class => 'span7' , :disabled => @resource.published? } %>
 


### PR DESCRIPTION
See [Shared issue 587](https://github.com/theodi/shared/issues/587) for requirements.

Have added the following levels to the Node form:

    network, learning, network_learning

As the tags are used for classes, they can't have spaces or odd characters.
Consqeuently also changed the form to have a label - value form, rather
than just values. This works with existing editions (tested with Seoul).

This correctly stores the information in the content database. 