### PR TITLE
Dockerizing the Publisher

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,6 +19,8 @@ Publisher::Application.configure do
   # Print deprecation notices to the Rails logger
   config.active_support.deprecation = :log
 
+  if defined? ENV['DOCKERIZED'] then config.logger = Logger.new(STDOUT) end
+
   config.action_mailer.default_url_options = { :host => "www.#{ENV['GOVUK_APP_DOMAIN']}" }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -1,12 +1,12 @@
 # This file is overwritten by one in alphagov-deployment at deploy time
 development:
-  host: localhost
+  host: <%= ENV['MONGOID_HOST'] ||= "localhost" %>
   database: govuk_content_development
   persist_in_safe_mode: true
   use_activesupport_time_zone: true
 
 test:
-  host: localhost
+  host: <%= ENV['MONGOID_HOST'] ||= "localhost" %>
   # Don't want this interfering with a concurrent Panopticon test run
   database: govuk_content_publisher_test
   use_activesupport_time_zone: true

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -6,7 +6,7 @@ development:
   use_activesupport_time_zone: true
 
 test:
-  host: <%= ENV['MONGOID_HOST'] ||= "localhost" %>
+  host: localhost
   # Don't want this interfering with a concurrent Panopticon test run
   database: govuk_content_publisher_test
   use_activesupport_time_zone: true

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -6,7 +6,7 @@ development:
   use_activesupport_time_zone: true
 
 test:
-  host: localhost
+  host: <%= ENV['MONGOID_HOST'] ||= "localhost" %>
   # Don't want this interfering with a concurrent Panopticon test run
   database: govuk_content_publisher_test
   use_activesupport_time_zone: true

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,2 +1,2 @@
-host: 127.0.0.1
+host: <%= ENV['REDIS_HOST'] ||= "localhost" %>
 port: 6379

--- a/lib/local_authority_data_importer.rb
+++ b/lib/local_authority_data_importer.rb
@@ -16,7 +16,7 @@ class LocalAuthorityDataImporter
   end
 
   def self.redis
-    redis_config = YAML.load_file(Rails.root.join("config", "redis.yml"))
+    redis_config = YAML.load(ERB.new(File.read(Rails.root.join("config", "redis.yml"))).result)
     Redis.new(redis_config.symbolize_keys)
   end
 

--- a/script/mail_fetcher
+++ b/script/mail_fetcher
@@ -17,7 +17,7 @@ require 'redis'
 require 'redis-lock'
 
 def redis
-  redis_config = YAML.load_file(File.join(Rails.root, "config", "redis.yml"))
+  redis_config = YAML.load(ERB.new(File.read(Rails.root.join("config", "redis.yml"))).result)
   Redis.new(redis_config.symbolize_keys)
 end
 


### PR DESCRIPTION
@Floppy I'm submitting this as a PR containing the changes that I had to make to bring Publisher up in a Docker image. They should be transparent to non-dockerized instances, as the changes are brought in by setting the following environment variables:

* `DOCKERIZED` (any value, as long as set) - switches in the logging to stdout
* `MONGOID_HOST` = hostname for Mongo DB
* `REDIS_HOST` = hostname for Redis

I also fixed some other locations where the Redis yml file was loaded, as these were causing tests to fail.

There is no urgency on this fix.